### PR TITLE
パスワードが平文で上書きされる不具合修正

### DIFF
--- a/MailMagazine.php
+++ b/MailMagazine.php
@@ -67,8 +67,8 @@ class MailMagazine
         if(is_null($Customer)) {
             return;
         }
-        $mode = $request->get('mode');
-        $EntryForm = $this->app['form.factory']->createBuilder('entry', $Customer)->getForm();
+        $cloneCustomer = clone $Customer;
+        $EntryForm = $this->app['form.factory']->createBuilder('entry', $cloneCustomer)->getForm();
         $EntryForm->handleRequest($request);
         if($request->get('mode') != 'complete' || !$EntryForm->isValid()) {
             return;


### PR DESCRIPTION
会員情報変更画面でパスワード変更を行った際に、本体でハッシュ化したパスワードを設定しているが、本プラグインで平文で上書きしてしまっている。

$app->user() も EntityManager から取得しているため、<code>$EntryForm->handleRequest($request);</code>でパスワードが平文で上書きされた後、MailmagaCustomerRepository::save で<code>$em->flush()</code>すると、$Customer も更新されてしまう。
