### PR TITLE
[FIX] Fix bug the plugin updates the password is not encrypted

### DIFF
--- a/MailMagazine.php
+++ b/MailMagazine.php
@@ -195,7 +195,10 @@ class MailMagazine
                 $diffs = array_values(array_diff($location, $url));
                 $id = $diffs[0];
             }
-            $Customer = $this->app['eccube.repository.customer']->find($id);
+            $CustomerRepo = $this->app['eccube.repository.customer']->find($id);
+
+            // Using clone to avoid doctrine preference (unitOfWork)
+            $Customer = clone $CustomerRepo;
 
             // メルマガFormを取得する
             $builder = $this->app['form.factory']->createBuilder('admin_customer', $Customer);


### PR DESCRIPTION
1. Problem: In screen customer management, event onRenderAdminCustomerBefore automatically change passwords (using unencrypted passwords stored in the database).
 - This will cause customers can not login.
2. Bug: Customer object will automatically update when changes are made to the database. (unitOfWork of doctrine - doctrine reference)
https://github.com/EC-CUBE/mail-magazine-plugin/blob/master/MailMagazine.php#L204
3. Suggest: Use clone object before handle.