### PR TITLE
ページングが動作しないの対応

### DIFF
--- a/Tests/Web/Admin/MailMagazineControllerTest.php
+++ b/Tests/Web/Admin/MailMagazineControllerTest.php
@@ -136,4 +136,55 @@ class MailMagazineControllerTest extends MailMagazineCommon
 //        $this->verify();
         $this->cleanUpMailCatcherMessages();
     }
+
+    public function testPagination()
+    {
+        for ($i = 0; $i < 30; $i++) {
+            $this->createMailMagazineCustomer();
+        }
+        $searchForm = array(
+            '_token' => 'dummy',
+            'sex' => array("1"),
+            "multi" => "",
+            "customer_status" => array(),
+            "birth_month" => "",
+            "birth_start" => "",
+            "birth_end" => "",
+            "pref" => "",
+            "tel" => array(),
+            "create_date_start" => "",
+            "create_date_end" => "",
+            "update_date_start" => "",
+            "update_date_end" => "",
+            "buy_total_start" => "",
+            "buy_total_end" => "",
+            "buy_times_start" => "",
+            "buy_times_end" => "",
+            "buy_product_code" => "",
+            "last_buy_start" => "",
+            "last_buy_end" => "",
+        );
+        $crawler = $this->client->request(
+            'POST',
+            $this->app->url('admin_mail_magazine'),
+            array('mail_magazine' => $searchForm)
+
+        );
+        $pageNumber = $crawler->filter('.box-title strong')->html();
+        $this->assertRegexp('/件/', $pageNumber);
+
+        //pagination
+        $crawler = $this->client->request(
+            'GET',
+            $this->app->url('admin_mail_magazine').'?page_no=2'
+        );
+
+        //check result
+        $pageNumber = $crawler->filter('.box-title strong')->html();
+        $this->assertRegexp('/件/', $pageNumber);
+
+        //check search condition
+        $sexCheckbox = $crawler->filter('#mail_magazine_sex label')->html();
+        $this->assertRegexp('/checked/', $sexCheckbox);
+    }
 }

--- a/View/admin/index.twig
+++ b/View/admin/index.twig
@@ -216,10 +216,15 @@ function fnChangeActionSubmit(action) {
                         <div class="col-md-12">
                             <ul class="sort-dd">
                                 <li class="dropdown">
-                                    <a class="dropdown-toggle" data-toggle="dropdown">20件<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"></svg></a>
+
+                                    {% for pageMax in pageMaxis if pageMax.name == page_count %}
+                                    <a class="dropdown-toggle" data-toggle="dropdown">{{ pageMax.name|e }}件<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"></svg></a>
+                                    {% endfor %}
+
                                     <ul class="dropdown-menu">
-                                        <li><a>50件</a></li>
-                                        <li><a>100件</a></li>
+                                        {% for pageMax in pageMaxis if pageMax.name != page_count %}
+                                            <li><a href="{{ path('admin_mail_magazine', {'page_no': 1, 'page_max': pageMax.name}) }}">{{ pageMax.name|e }}件</a></li>
+                                        {% endfor %}
                                     </ul>
                                 </li>
                                 {# var3.0.0では未対応


### PR DESCRIPTION
EC-CUBE3.0系のメルマガ管理プラグインにて
「配信内容設定」画面で、条件を入力して検索した結果が10件以上の場合にページネーションがつきます。
このページネーションで1ページ目以降に遷移しようとしても、遷移できず検索画面のトップに戻ってしまいます。
以上のバグを対応し、ユニットテストも追加しました。
