### PR TITLE
EC-CUBE 3.0.18で動作するようにserialize/unserializeを利用しない実装に変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ env:
     PLUGIN_CODE=MailMagazine
   matrix:
     # ec-cube master
-    - ECCUBE_VERSION=3.1 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.1 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+  #    - ECCUBE_VERSION=3.1 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+  #    - ECCUBE_VERSION=3.1 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.8
-    - ECCUBE_VERSION=3.0.8-for-plugin-test DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.8-for-plugin-test DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+  #    - ECCUBE_VERSION=3.0.8-for-plugin-test DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+  #    - ECCUBE_VERSION=3.0.8-for-plugin-test DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.17
-    - ECCUBE_VERSION=3.0.17 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+  #    - ECCUBE_VERSION=3.0.17 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.17 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.x
     - ECCUBE_VERSION=3.0 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
@@ -51,14 +51,6 @@ matrix:
       env: ECCUBE_VERSION=3.0.8-for-plugin-test DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - php: 7.1
       env: ECCUBE_VERSION=3.0.8-for-plugin-test DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    - php: 7.0
-      env: ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - php: 7.0
-      env: ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    - php: 7.1
-      env: ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - php: 7.1
-      env: ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 
 install:
   - gem install mime-types -v 2.99.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ env:
     PLUGIN_CODE=MailMagazine
   matrix:
     # ec-cube master
-  #    - ECCUBE_VERSION=3.1 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-  #    - ECCUBE_VERSION=3.1 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    - ECCUBE_VERSION=3.1 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.1 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.8
-  #    - ECCUBE_VERSION=3.0.8-for-plugin-test DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-  #    - ECCUBE_VERSION=3.0.8-for-plugin-test DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    - ECCUBE_VERSION=3.0.8-for-plugin-test DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.0.8-for-plugin-test DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.17
-  #    - ECCUBE_VERSION=3.0.17 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.0.17 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.17 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.x
     - ECCUBE_VERSION=3.0 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,15 @@ env:
     # ec-cube master
     - ECCUBE_VERSION=3.1 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.1 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    # ec-cube 3.0.9
-    - ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.8
     - ECCUBE_VERSION=3.0.8-for-plugin-test DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.8-for-plugin-test DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    # ec-cube 3.0.16
-    - ECCUBE_VERSION=3.0.16 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.16 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.17
     - ECCUBE_VERSION=3.0.17 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.17 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    # ec-cube 3.0.x
+    - ECCUBE_VERSION=3.0 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.0 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 matrix:
   fail_fast: true
   fast_finish: true
@@ -75,8 +72,9 @@ before_script:
   - git clone https://github.com/EC-CUBE/ec-cube.git
   - cd ec-cube
   # checkout version
+  - sh -c "if [ '${ECCUBE_VERSION}' = '3.0' ]; then  git checkout -b ${ECCUBE_VERSION} origin/${ECCUBE_VERSION}; fi"
   - sh -c "if [ '${ECCUBE_VERSION}' = '3.1' ]; then  git checkout -b ${ECCUBE_VERSION} origin/${ECCUBE_VERSION}; fi"
-  - sh -c "if [ ! '${ECCUBE_VERSION}' = '3.1' ]; then  git checkout -b ${ECCUBE_VERSION} refs/tags/${ECCUBE_VERSION}; fi"
+  - sh -c "if [ ! '${ECCUBE_VERSION}' = '3.1' -a ! '${ECCUBE_VERSION}' = '3.0' ]; then  git checkout -b ${ECCUBE_VERSION} refs/tags/${ECCUBE_VERSION}; fi"
   # update composer
   - composer selfupdate
   - composer install --dev --no-interaction -o

--- a/Controller/MailMagazineController.php
+++ b/Controller/MailMagazineController.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
- * Class MailMagazineController
+ * Class MailMagazineController.
  */
 class MailMagazineController
 {

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -123,7 +123,11 @@ class MailMagazineHistoryController
 
         $searchData = $searchDataArray = json_decode($sendHistory->getSearchData(), true);
 
-        $searchData['pref'] = $app['eccube.repository.master.pref']->find($searchDataArray['pref']['id']);
+        if ($searchDataArray['pref'] != null) {
+            $searchData['pref'] = $app['eccube.repository.master.pref']->find($searchDataArray['pref']['id']);
+        } else {
+            $searchData['pref'] = null;
+        }
 
         $searchData['sex'] = new ArrayCollection();
         $searchData['customer_status'] = new ArrayCollection();

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -13,6 +13,7 @@ namespace Plugin\MailMagazine\Controller;
 
 use Eccube\Application;
 use Eccube\Common\Constant;
+use Eccube\Entity\Master\Pref;
 use Knp\Component\Pager\Paginator;
 use Plugin\MailMagazine\Entity\MailMagazineSendHistory;
 use Plugin\MailMagazine\Repository\MailMagazineSendHistoryRepository;
@@ -20,6 +21,7 @@ use Plugin\MailMagazine\Service\MailMagazineService;
 use Plugin\MailMagazine\Util\MailMagazineHistoryFilePaginationSubscriber;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class MailMagazineHistoryController
 {
@@ -119,9 +121,19 @@ class MailMagazineHistoryController
             return $app->redirect($app->url('plugin_mail_magazine_history'));
         }
 
-        // 検索条件をアンシリアライズする
-        // base64,serializeされているので注意すること
-        $searchData = unserialize(base64_decode($sendHistory->getSearchData()));
+        $searchData = $searchDataArray = json_decode($sendHistory->getSearchData(), true);
+
+        $searchData['pref'] = $app['eccube.repository.master.pref']->find($searchDataArray['pref']['id']);
+
+        $searchData['sex'] = new ArrayCollection();
+        $searchData['customer_status'] = new ArrayCollection();
+
+        foreach ($searchDataArray['sex'] as $value) {
+            $searchData['sex']->add($app['eccube.repository.master.sex']->find($value['id']));
+        }
+        foreach ($searchDataArray['customer_status'] as $value) {
+            $searchData['customer_status']->add($app['eccube.repository.customer_status']->find($value['id']));
+        }
 
         // 区分値を文字列に変更する
         // 必要な項目のみ

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -124,7 +124,7 @@ class MailMagazineHistoryController
         // DBからjsonで取得したデータをオブジェクトで再生成する
         $searchData = $searchDataArray = json_decode($sendHistory->getSearchData(), true);
 
-        if ($searchDataArray['pref'] != null) {
+        if (array_key_exists('pref', $searchDataArray) && array_key_exists('id', $searchDataArray['pref']) && is_numeric($searchDataArray['pref']['id'])) {
             $searchData['pref'] = $app['eccube.repository.master.pref']->find($searchDataArray['pref']['id']);
         } else {
             $searchData['pref'] = null;

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -195,8 +195,8 @@ class MailMagazineHistoryController
         // 会員種別
         $val = null;
         if (!is_null($searchData['customer_status'])) {
-            if (count($searchData['customer_status']->toArray()) > 0) {
-                $val = implode(' ', $searchData['customer_status']->toArray());
+            if (count($searchData['customer_status']) > 0) {
+                $val = implode(' ', $searchData['customer_status']);
             }
         }
         $data['customer_status'] = $val;
@@ -204,8 +204,8 @@ class MailMagazineHistoryController
         // 性別
         $val = null;
         if (!is_null($searchData['sex'])) {
-            if (count($searchData['sex']->toArray()) > 0) {
-                $val = implode(' ', $searchData['sex']->toArray());
+            if (count($searchData['sex']) > 0) {
+                $val = implode(' ', $searchData['sex']);
             }
         }
         $data['sex'] = $val;

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -132,11 +132,15 @@ class MailMagazineHistoryController
         $searchData['sex'] = new ArrayCollection();
         $searchData['customer_status'] = new ArrayCollection();
 
-        foreach ($searchDataArray['sex'] as $value) {
-            $searchData['sex']->add($app['eccube.repository.master.sex']->find($value['id']));
+        if ($searchDataArray['sex'] != null) {
+            foreach ($searchDataArray['sex'] as $value) {
+                $searchData['sex']->add($app['eccube.repository.master.sex']->find($value['id']));
+            }
         }
-        foreach ($searchDataArray['customer_status'] as $value) {
-            $searchData['customer_status']->add($app['eccube.repository.customer_status']->find($value['id']));
+        if ($searchDataArray['customer_status'] != null) {
+            foreach ($searchDataArray['customer_status'] as $value) {
+                $searchData['customer_status']->add($app['eccube.repository.customer_status']->find($value['id']));
+            }
         }
 
         // 区分値を文字列に変更する

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -122,6 +122,7 @@ class MailMagazineHistoryController
             return $app->redirect($app->url('plugin_mail_magazine_history'));
         }
 
+        // DBからjsonで取得したデータをオブジェクトで再生成する
         $searchData = $searchDataArray = json_decode($sendHistory->getSearchData(), true);
 
         if ($searchDataArray['pref'] != null) {

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -133,21 +133,43 @@ class MailMagazineHistoryController
         $searchData['sex'] = new ArrayCollection();
         $searchData['customer_status'] = new ArrayCollection();
 
-        if ($searchDataArray['sex'] != null) {
-            foreach ($searchDataArray['sex'] as $value) {
-                $searchData['sex']->add($app['eccube.repository.master.sex']->find($value['id']));
-            }
+        if (array_key_exists('sex', $searchDataArray) && is_array($searchDataArray['sex'])) {
+            $searchData['sex'] = $app['eccube.repository.master.sex']->findBy(
+                array(
+                    'id' => array_filter(
+                        array_map(function ($value) {
+                            if (array_key_exists('id', $value)) {
+                                return $value['id'];
+                            }
+                            return false;
+                        }, $searchDataArray['sex']
+                        )
+                    )
+                )
+            );
         }
-        if ($searchDataArray['customer_status'] != null) {
-            foreach ($searchDataArray['customer_status'] as $value) {
-                $searchData['customer_status']->add($app['eccube.repository.customer_status']->find($value['id']));
-            }
+
+        if (array_key_exists('customer_status', $searchDataArray) && is_array($searchDataArray['customer_status'])) {
+            $searchData['customer_status'] = $app['eccube.repository.customer_status']->findBy(
+                array(
+                    'id' => array_filter(
+                        array_map(function ($value) {
+                            if (array_key_exists('id', $value)) {
+                                return $value['id'];
+                            }
+                            return false;
+                        }, $searchDataArray['customer_status']
+                        )
+                    )
+                )
+            );
         }
+
         foreach ($searchDataArray as $key => $value) {
             if ( ! is_array($value) || ! array_key_exists('date', $value)) {
                 continue;
             }
-            $searchData[$key] = new DateTime($value['date']);
+            $searchData[$key] = new \DateTime($value['date']);
         }
 
         // 区分値を文字列に変更する

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -141,10 +141,11 @@ class MailMagazineHistoryController
                             if (array_key_exists('id', $value)) {
                                 return $value['id'];
                             }
+
                             return false;
                         }, $searchDataArray['sex']
                         )
-                    )
+                    ),
                 )
             );
         }
@@ -157,16 +158,17 @@ class MailMagazineHistoryController
                             if (array_key_exists('id', $value)) {
                                 return $value['id'];
                             }
+
                             return false;
                         }, $searchDataArray['customer_status']
                         )
-                    )
+                    ),
                 )
             );
         }
 
         foreach ($searchDataArray as $key => $value) {
-            if ( ! is_array($value) || ! array_key_exists('date', $value)) {
+            if (!is_array($value) || !array_key_exists('date', $value)) {
                 continue;
             }
             $searchData[$key] = new \DateTime($value['date']);

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -11,6 +11,7 @@
 
 namespace Plugin\MailMagazine\Controller;
 
+use DateTime;
 use Eccube\Application;
 use Eccube\Common\Constant;
 use Eccube\Entity\Master\Pref;
@@ -141,6 +142,12 @@ class MailMagazineHistoryController
             foreach ($searchDataArray['customer_status'] as $value) {
                 $searchData['customer_status']->add($app['eccube.repository.customer_status']->find($value['id']));
             }
+        }
+        foreach ($searchDataArray as $key => $value) {
+            if ( ! is_array($value) || ! array_key_exists('date', $value)) {
+                continue;
+            }
+            $searchData[$key] = new DateTime($value['date']);
         }
 
         // 区分値を文字列に変更する

--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -11,7 +11,6 @@
 
 namespace Plugin\MailMagazine\Controller;
 
-use DateTime;
 use Eccube\Application;
 use Eccube\Common\Constant;
 use Eccube\Entity\Master\Pref;

--- a/Form/Type/MailMagazineType.php
+++ b/Form/Type/MailMagazineType.php
@@ -174,10 +174,6 @@ class MailMagazineType extends AbstractType
                     new Assert\Length(array('max' => $config['stext_len'])),
                 ),
             ))
-            ->add('buy_category', 'category', array(
-                'label' => '商品カテゴリ',
-                'required' => false,
-            ))
           // TODO DBから取得するのが正しいので修正
 //             ->add('customer_status', 'choice', array(
 //                 'label' => '会員ステータス',

--- a/Repository/MailMagazineTemplateRepository.php
+++ b/Repository/MailMagazineTemplateRepository.php
@@ -60,6 +60,7 @@ class MailMagazineTemplateRepository extends EntityRepository
         } catch (\Exception $e) {
             $em->getConnection()->rollback();
             throw $e;
+
             return false;
         }
 
@@ -85,6 +86,7 @@ class MailMagazineTemplateRepository extends EntityRepository
         } catch (\Exception $e) {
             $em->getConnection()->rollback();
             throw $e;
+
             return false;
         }
 
@@ -109,6 +111,7 @@ class MailMagazineTemplateRepository extends EntityRepository
         } catch (\Exception $e) {
             $em->getConnection()->rollback();
             throw $e;
+
             return false;
         }
 

--- a/Resource/doctrine/migration/Version201906031100.php
+++ b/Resource/doctrine/migration/Version201906031100.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Eccube\Application;
+
+class Version201906031100 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+
+        $app = Application::getInstance();
+        $repository = $app['orm.em']->getRepository("\Plugin\MailMagazine\Entity\MailMagazineSendHistory");
+
+        $entities = $repository->createQueryBuilder('sh')
+            ->select('sh.id, sh.search_data')
+            ->orderBy('sh.id', 'ASC')
+            ->getQuery()
+            ->getArrayResult();
+
+        foreach ($entities as $entity) {
+            $formData = unserialize(base64_decode($entity['search_data']));
+
+            // unserializeしたデータからJSONに変換
+            $formDataArray = $formData;
+            $formDataArray['pref'] = ($formData['pref'] != null) ? $formData['pref']->toArray() : null;
+            $formDataArray['sex'] = array();
+            foreach ($formData['sex'] as $value) {
+                $formDataArray['sex'][] = $value->toArray();
+            }
+            $formDataArray['customer_status'] = array();
+            foreach ($formData['customer_status'] as $value) {
+                $formDataArray['customer_status'][] = $value->toArray();
+            }
+            unset($formDataArray['buy_category']);
+
+            $json = json_encode($formDataArray);
+
+            // search_dataをUPDATEする
+
+            $qb = $repository->createQueryBuilder('sh');
+            $qb->update("\Plugin\MailMagazine\Entity\MailMagazineSendHistory", 'sh')
+                ->set('sh.search_data', $qb->expr()->literal($json))
+                ->where('sh.id = :id')
+                ->setParameter('id', $entity['id'])
+                ->getQuery()
+                ->execute();
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/Resource/doctrine/migration/Version201906031100.php
+++ b/Resource/doctrine/migration/Version201906031100.php
@@ -6,7 +6,9 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Eccube\Application;
 use Eccube\Common\Constant;
+use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Entity\Master\Pref;
+use Eccube\Entity\Master\Sex;
 use Symfony\Component\Yaml\Yaml;
 
 class Version201906031100 extends AbstractMigration
@@ -37,14 +39,20 @@ class Version201906031100 extends AbstractMigration
             // unserializeしたデータからJSONに変換
             $formDataArray = $formData;
             $formDataArray['pref'] = ($formData['pref'] instanceof Pref) ? $formData['pref']->toArray() : null;
-            $formDataArray['sex'] = array();
-            foreach ($formData['sex'] as $value) {
-                $formDataArray['sex'][] = $value->toArray();
-            }
-            $formDataArray['customer_status'] = array();
-            foreach ($formData['customer_status'] as $value) {
-                $formDataArray['customer_status'][] = $value->toArray();
-            }
+            $formDataArray['sex'] = array_filter(array_map(function ($entity) {
+                if ($entity instanceof Sex) {
+                    return $entity->toArray();
+                } else {
+                    return false;
+                }
+            }, $formData['sex']));
+            $formDataArray['customer_status'] = array_filter(array_map(function ($entity) {
+                if ($entity instanceof CustomerStatus) {
+                    return $entity->toArray();
+                } else {
+                    return false;
+                }
+            }, $formData['customer_status']));
             unset($formDataArray['buy_category']);
 
             $json = json_encode($formDataArray);

--- a/Resource/doctrine/migration/Version201906031100.php
+++ b/Resource/doctrine/migration/Version201906031100.php
@@ -17,7 +17,8 @@ class Version201906031100 extends AbstractMigration
         $stmt = $pdo->prepare("SELECT send_id, search_data FROM plg_send_history;");
         $stmt->execute();
         foreach ($stmt as $row) {
-            $formData = unserialize(base64_decode($row['search_data']));
+            $serializedData = str_replace('DoctrineProxy\__CG__\Eccube\Entity\Member', 'DoctrineProxy\__CG__\Eccube\Entity\Xxxxxx', base64_decode($row['search_data']));
+            $formData = unserialize($serializedData);
             // unserializeしたデータからJSONに変換
             $formDataArray = $formData;
             $formDataArray['pref'] = ($formData['pref'] != null) ? $formData['pref']->toArray() : null;

--- a/Resource/doctrine/migration/Version201906031100.php
+++ b/Resource/doctrine/migration/Version201906031100.php
@@ -58,7 +58,7 @@ class Version201906031100 extends AbstractMigration
             $json = json_encode($formDataArray);
 
             // search_dataをUPDATEする
-            $stmt = $pdo->prepare("UPDATE plg_send_history SET search_data = :search_data WHERE send_id = :send_id;");
+            $stmt = $pdo->prepare('UPDATE plg_send_history SET search_data = :search_data WHERE send_id = :send_id;');
             $stmt->execute(array(':search_data' => $json, ':send_id' => $row['send_id']));
         }
     }
@@ -69,20 +69,23 @@ class Version201906031100 extends AbstractMigration
 
     /**
      * 互換性のないEntityを取り除いた状態でUnserialiseを実行する
-     * Member,Customerは "__php_incomplete_class"となる
+     * Member,Customerは "__php_incomplete_class"となる.
      *
      * @param array $serializedData Base64でエンコードされたシリアライズデータ
+     *
      * @return mixed unserializeしたデータ
      */
-    private function unserializeWrapper($serializedData) {
+    private function unserializeWrapper($serializedData)
+    {
         $serializedData = str_replace('DoctrineProxy\__CG__\Eccube\Entity\Member', '__Workaround_\__CG__\Eccube\Entity\Member', $serializedData);
         $serializedData = str_replace('DoctrineProxy\__CG__\Eccube\Entity\Customer', '__Workaround_\__CG__\Eccube\Entity\Customer', $serializedData);
+
         return unserialize($serializedData);
     }
 
     private function getPDO()
     {
-        $config_file = __DIR__ . '/../../../../../../app/config/eccube/database.yml';
+        $config_file = __DIR__.'/../../../../../../app/config/eccube/database.yml';
         $config = Yaml::parse(file_get_contents($config_file));
 
         $pdo = null;
@@ -91,10 +94,10 @@ class Version201906031100 extends AbstractMigration
             $pdo->connect();
         } catch (\Exception $e) {
             $pdo->close();
+
             return null;
         }
 
         return $pdo;
     }
-
 }

--- a/Resource/doctrine/migration/Version201906031100.php
+++ b/Resource/doctrine/migration/Version201906031100.php
@@ -45,14 +45,14 @@ class Version201906031100 extends AbstractMigration
                 } else {
                     return false;
                 }
-            }, $formData['sex']));
+            }, $formData['sex']->toArray()));
             $formDataArray['customer_status'] = array_filter(array_map(function ($entity) {
                 if ($entity instanceof CustomerStatus) {
                     return $entity->toArray();
                 } else {
                     return false;
                 }
-            }, $formData['customer_status']));
+            }, $formData['customer_status']->toArray()));
             unset($formDataArray['buy_category']);
 
             $json = json_encode($formDataArray);

--- a/Resource/doctrine/migration/Version201906031100.php
+++ b/Resource/doctrine/migration/Version201906031100.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Eccube\Application;
 use Eccube\Common\Constant;
+use Eccube\Entity\Master\Pref;
 use Symfony\Component\Yaml\Yaml;
 
 class Version201906031100 extends AbstractMigration
@@ -35,7 +36,7 @@ class Version201906031100 extends AbstractMigration
 
             // unserializeしたデータからJSONに変換
             $formDataArray = $formData;
-            $formDataArray['pref'] = ($formData['pref'] != null) ? $formData['pref']->toArray() : null;
+            $formDataArray['pref'] = ($formData['pref'] instanceof Pref) ? $formData['pref']->toArray() : null;
             $formDataArray['sex'] = array();
             foreach ($formData['sex'] as $value) {
                 $formDataArray['sex'][] = $value->toArray();

--- a/Resource/doctrine/migration/Version201906031100.php
+++ b/Resource/doctrine/migration/Version201906031100.php
@@ -15,23 +15,11 @@ class Version201906031100 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
-        // 3.0.8以前はgetInstance関数が無いことを考慮する
-        if (version_compare(Constant::VERSION, '3.0.9', '>=')) {
-            $app = Application::getInstance();
-            $entityManager = $app['orm.em'];
-            $pdo = $entityManager->getConnection()->getWrappedConnection();
-        } else {
-            // 直接DBに接続してPDOを生成
-            $pdo = $this->getPDO();
-        }
+        $pdo = $this->connection->getWrappedConnection();
 
         // search_dataをserializeされたデータからjson形式に変換する
-        try {
-            $stmt = $pdo->prepare('SELECT send_id, search_data FROM plg_send_history;');
-            $stmt->execute();
-        } catch (\Exception $e) {
-            return;
-        }
+        $stmt = $pdo->prepare('SELECT send_id, search_data FROM plg_send_history;');
+        $stmt->execute();
 
         foreach ($stmt as $row) {
             $formData = $this->unserializeWrapper(base64_decode($row['search_data']));

--- a/Resource/doctrine/migration/Version201906031100.php
+++ b/Resource/doctrine/migration/Version201906031100.php
@@ -23,8 +23,13 @@ class Version201906031100 extends AbstractMigration
         }
 
         // search_dataをserializeされたデータからjson形式に変換する
-        $stmt = $pdo->prepare('SELECT send_id, search_data FROM plg_send_history;');
-        $stmt->execute();
+        try {
+            $stmt = $pdo->prepare('SELECT send_id, search_data FROM plg_send_history;');
+            $stmt->execute();
+        } catch (\Exception $e) {
+            return;
+        }
+
         foreach ($stmt as $row) {
             $formData = $this->unserializeWrapper(base64_decode($row['search_data']));
 

--- a/Resource/doctrine/migration/Version201906031100.php
+++ b/Resource/doctrine/migration/Version201906031100.php
@@ -12,19 +12,22 @@ class Version201906031100 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
+        // 3.0.8以前はgetInstance関数が無いことを考慮する
         if (version_compare(Constant::VERSION, '3.0.9', '>=')) {
             $app = Application::getInstance();
             $entityManager = $app['orm.em'];
-            // Retrieve PDO instance
             $pdo = $entityManager->getConnection()->getWrappedConnection();
         } else {
+            // 直接DBに接続してPDOを生成
             $pdo = $this->getPDO();
         }
 
+        // search_dataをserializeされたデータからjson形式に変換する
         $stmt = $pdo->prepare('SELECT send_id, search_data FROM plg_send_history;');
         $stmt->execute();
         foreach ($stmt as $row) {
-            $formData = $this->unserializeWrapper($row, 'search_data');
+            $formData = $this->unserializeWrapper(base64_decode($row['search_data']));
+
             // unserializeしたデータからJSONに変換
             $formDataArray = $formData;
             $formDataArray['pref'] = ($formData['pref'] != null) ? $formData['pref']->toArray() : null;
@@ -50,8 +53,14 @@ class Version201906031100 extends AbstractMigration
     {
     }
 
-    private function unserializeWrapper($dataArray, $key) {
-        $serializedData = base64_decode($dataArray[$key]);
+    /**
+     * 互換性のないEntityを取り除いた状態でUnserialiseを実行する
+     * Member,Customerは "__php_incomplete_class"となる
+     *
+     * @param array $serializedData Base64でエンコードされたシリアライズデータ
+     * @return mixed unserializeしたデータ
+     */
+    private function unserializeWrapper($serializedData) {
         $serializedData = str_replace('DoctrineProxy\__CG__\Eccube\Entity\Member', '__Workaround_\__CG__\Eccube\Entity\Member', $serializedData);
         $serializedData = str_replace('DoctrineProxy\__CG__\Eccube\Entity\Customer', '__Workaround_\__CG__\Eccube\Entity\Customer', $serializedData);
         return unserialize($serializedData);

--- a/Resource/template/admin/history_condition.twig
+++ b/Resource/template/admin/history_condition.twig
@@ -84,13 +84,13 @@
                             {% if search_data.birth_start is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.birth_start|date("Y/m/d") }}
+                                {{ search_data.birth_start.date|date("Y/m/d") }}
                             {% endif %}
                             ～
                             {% if search_data.birth_end is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.birth_end|date("Y/m/d") }}
+                                {{ search_data.birth_end.date|date("Y/m/d") }}
                             {% endif %}
                         </td>
                     </tr>
@@ -132,13 +132,13 @@
                             {% if search_data.create_date_start is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.create_date_start|date("Y/m/d") }}
+                                {{ search_data.create_date_start.date|date("Y/m/d") }}
                             {% endif %}
                             ～
                             {% if search_data.create_date_end is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.create_date_end|date("Y/m/d") }}
+                                {{ search_data.create_date_end.date|date("Y/m/d") }}
                             {% endif %}
                         </td>
                     </tr>
@@ -148,13 +148,13 @@
                             {% if search_data.update_date_start is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.update_date_start|date("Y/m/d") }}
+                                {{ search_data.update_date_start.date|date("Y/m/d") }}
                             {% endif %}
                             ～
                             {% if search_data.update_date_end is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.update_date_end|date("Y/m/d") }}
+                                {{ search_data.update_date_end.date|date("Y/m/d") }}
                             {% endif %}
                         </td>
                     </tr>
@@ -206,13 +206,13 @@
                             {% if search_data.last_buy_start is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.last_buy_start|date("Y/m/d") }}
+                                {{ search_data.last_buy_start.date|date("Y/m/d") }}
                             {% endif %}
                             ～
                             {% if search_data.last_buy_end is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.last_buy_end|date("Y/m/d") }}
+                                {{ search_data.last_buy_end.date|date("Y/m/d") }}
                             {% endif %}
                         </td>
                     </tr>

--- a/Resource/template/admin/history_condition.twig
+++ b/Resource/template/admin/history_condition.twig
@@ -84,13 +84,13 @@
                             {% if search_data.birth_start is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.birth_start.date|date("Y/m/d") }}
+                                {{ search_data.birth_start|date("Y/m/d") }}
                             {% endif %}
                             ～
                             {% if search_data.birth_end is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.birth_end.date|date("Y/m/d") }}
+                                {{ search_data.birth_end|date("Y/m/d") }}
                             {% endif %}
                         </td>
                     </tr>
@@ -132,13 +132,13 @@
                             {% if search_data.create_date_start is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.create_date_start.date|date("Y/m/d") }}
+                                {{ search_data.create_date_start|date("Y/m/d") }}
                             {% endif %}
                             ～
                             {% if search_data.create_date_end is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.create_date_end.date|date("Y/m/d") }}
+                                {{ search_data.create_date_end|date("Y/m/d") }}
                             {% endif %}
                         </td>
                     </tr>
@@ -148,13 +148,13 @@
                             {% if search_data.update_date_start is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.update_date_start.date|date("Y/m/d") }}
+                                {{ search_data.update_date_start|date("Y/m/d") }}
                             {% endif %}
                             ～
                             {% if search_data.update_date_end is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.update_date_end.date|date("Y/m/d") }}
+                                {{ search_data.update_date_end|date("Y/m/d") }}
                             {% endif %}
                         </td>
                     </tr>
@@ -206,13 +206,13 @@
                             {% if search_data.last_buy_start is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.last_buy_start.date|date("Y/m/d") }}
+                                {{ search_data.last_buy_start|date("Y/m/d") }}
                             {% endif %}
                             ～
                             {% if search_data.last_buy_end is null %}
                                 (未指定)
                             {% else %}
-                                {{ search_data.last_buy_end.date|date("Y/m/d") }}
+                                {{ search_data.last_buy_end|date("Y/m/d") }}
                             {% endif %}
                         </td>
                     </tr>

--- a/Resource/template/admin/index.twig
+++ b/Resource/template/admin/index.twig
@@ -183,15 +183,6 @@ function fnChangeActionSubmit(action) {
                                             {{ form_widget(searchForm.buy_times_start) }} ～ {{ form_widget(searchForm.buy_times_end) }}
                                         </div>
                                     </div>
-                                    {#
-                                    <div class="col-md-6">
-                                        <div class="form-group">
-                                            <label>購入商品カテゴリー</label>
-                                            {{ form_widget(searchForm.buy_category) }}
-                                            </select>
-                                        </div>
-                                    </div>
-                                    #}
                                     <div class="col-md-6">
                                         <div class="form-group">
                                             <label>購入商品名・コード</label>

--- a/Service/MailMagazineService.php
+++ b/Service/MailMagazineService.php
@@ -171,8 +171,21 @@ class MailMagazineService
         unset($formData['subject']);
         unset($formData['body']);
 
+        $formDataArray = $formData;
+
+        $formDataArray['pref'] = ($formData['pref'] != null) ? $formData['pref']->toArray() : null;
+        $formDataArray['sex'] = array();
+        foreach ($formData['sex'] as $value) {
+            $formDataArray['sex'][] = $value->toArray();
+        }
+
+        $formDataArray['customer_status'] = array();
+        foreach ($formData['customer_status'] as $value) {
+            $formDataArray['customer_status'][] = $value->toArray();
+        }
+
         // serializeのみだとDB登録時にデータが欠損するのでBase64にする
-        $sendHistory->setSearchData(base64_encode(serialize($formData)));
+        $sendHistory->setSearchData(json_encode($formDataArray));
 
         $status = $this->app[self::REPOSITORY_SEND_HISTORY]->createSendHistory($sendHistory);
         if (!$status) {

--- a/Service/MailMagazineService.php
+++ b/Service/MailMagazineService.php
@@ -98,9 +98,9 @@ class MailMagazineService
      * メールを送信する.
      *
      * @param array $formData メルマガ情報
-     *                  email: 送信先メールアドレス
-     *                  subject: 件名
-     *                  body：本文
+     *                        email: 送信先メールアドレス
+     *                        subject: 件名
+     *                        body：本文
      */
     public function sendMail($formData)
     {

--- a/Service/MailMagazineService.php
+++ b/Service/MailMagazineService.php
@@ -13,6 +13,7 @@ namespace Plugin\MailMagazine\Service;
 
 use Eccube\Application;
 use Eccube\Common\Constant;
+use Eccube\Entity\Master\Pref;
 use Plugin\MailMagazine\Entity\MailMagazineSendHistory;
 use Plugin\MailMagazine\Repository\MailMagazineCustomerRepository;
 
@@ -174,7 +175,7 @@ class MailMagazineService
         // jsonエンコード用にオブジェクトを配列化してDBに保存する
         $formDataArray = $formData;
 
-        $formDataArray['pref'] = ($formData['pref'] != null) ? $formData['pref']->toArray() : null;
+        $formDataArray['pref'] = ($formData['pref'] instanceof Pref) ? $formData['pref']->toArray() : null;
         $formDataArray['sex'] = array();
         foreach ($formData['sex'] as $value) {
             $formDataArray['sex'][] = $value->toArray();

--- a/Service/MailMagazineService.php
+++ b/Service/MailMagazineService.php
@@ -171,6 +171,7 @@ class MailMagazineService
         unset($formData['subject']);
         unset($formData['body']);
 
+        // jsonエンコード用にオブジェクトを配列化してDBに保存する
         $formDataArray = $formData;
 
         $formDataArray['pref'] = ($formData['pref'] != null) ? $formData['pref']->toArray() : null;
@@ -184,9 +185,9 @@ class MailMagazineService
             $formDataArray['customer_status'][] = $value->toArray();
         }
 
-        // serializeのみだとDB登録時にデータが欠損するのでBase64にする
         $sendHistory->setSearchData(json_encode($formDataArray));
 
+        // 履歴ファイルの書出し
         $status = $this->app[self::REPOSITORY_SEND_HISTORY]->createSendHistory($sendHistory);
         if (!$status) {
             return null;

--- a/Tests/AbstractMailMagazineTestCase.php
+++ b/Tests/AbstractMailMagazineTestCase.php
@@ -2,7 +2,9 @@
 
 namespace Plugin\MailMagazine\Tests;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Eccube\Common\Constant;
+use Eccube\Entity\Master\Pref;
 use Eccube\Tests\Service\AbstractServiceTestCase;
 use Plugin\MailMagazine\Entity\MailmagaCustomer;
 use Plugin\MailMagazine\Service\MailMagazineService;
@@ -59,6 +61,9 @@ abstract class AbstractMailMagazineTestCase extends AbstractServiceTestCase
     protected function createHistory(\Eccube\Entity\Customer $Customer)
     {
         return $this->mailMagazineService->createMailMagazineHistory(array(
+            'pref' => null,
+            'sex' => new ArrayCollection(),
+            'customer_status' => new ArrayCollection(),
             'subject' => 'subject',
             'body' => 'body',
             'multi' => $Customer->getEmail(),

--- a/Tests/Service/MailMagazineServiceTest.php
+++ b/Tests/Service/MailMagazineServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Plugin\MailMagazine\Tests\Service;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Eccube\Entity\Master\Pref;
 use Plugin\MailMagazine\Entity\MailMagazineSendHistory;
 use Plugin\MailMagazine\Tests\AbstractMailMagazineTestCase;
 
@@ -40,6 +42,9 @@ class MailMagazineServiceTest extends AbstractMailMagazineTestCase
         $this->createMailmagaCustomer('3_create_mail_magazine_history@example.com', 'name01_3', 'name02_3');
 
         $expectedId = $this->mailMagazineService->createMailMagazineHistory(array(
+            'pref' => null,
+            'sex' => new ArrayCollection(),
+            'customer_status' => new ArrayCollection(),
             'subject' => 'subject',
             'body' => 'body',
             'multi' => 'create_mail_magazine_history@example.com',
@@ -61,6 +66,9 @@ class MailMagazineServiceTest extends AbstractMailMagazineTestCase
         $c3 = $this->createMailmagaCustomer('3_create_mail_magazine_history@example.com', 'name01_3', 'name02_3');
 
         $actualId = $this->mailMagazineService->createMailMagazineHistory(array(
+            'pref' => null,
+            'sex' => new ArrayCollection(),
+            'customer_status' => new ArrayCollection(),
             'subject' => 'subject',
             'body' => 'body',
             'multi' => 'create_mail_magazine_history@example.com',
@@ -73,6 +81,7 @@ class MailMagazineServiceTest extends AbstractMailMagazineTestCase
         $expected = '0,'.$c1->getId().',1_create_mail_magazine_history@example.com,name01_1 name02_1'.PHP_EOL.
                     '0,'.$c2->getId().',2_create_mail_magazine_history@example.com,name01_2 name02_2'.PHP_EOL.
                     '0,'.$c3->getId().',3_create_mail_magazine_history@example.com,name01_3 name02_3'.PHP_EOL;
+
         self::assertEquals($expected, file_get_contents($fileName));
     }
 
@@ -194,6 +203,9 @@ class MailMagazineServiceTest extends AbstractMailMagazineTestCase
         $c3 = $this->createMailmagaCustomer('3_create_mail_magazine_history@example.com', 'name01_3', 'name02_3');
 
         $historyId = $this->mailMagazineService->createMailMagazineHistory(array(
+            'pref' => null,
+            'sex' => new ArrayCollection(),
+            'customer_status' => new ArrayCollection(),
             'subject' => 'subject',
             'body' => 'body',
             'multi' => 'create_mail_magazine_history@example.com',
@@ -238,6 +250,9 @@ class MailMagazineServiceTest extends AbstractMailMagazineTestCase
         );
 
         $historyId = $this->mailMagazineService->createMailMagazineHistory(array(
+            'pref' => null,
+            'sex' => new ArrayCollection(),
+            'customer_status' => new ArrayCollection(),
             'subject' => 'subject',
             'body' => 'body',
             'multi' => 'create_mail_magazine_history@example.com',
@@ -283,6 +298,9 @@ class MailMagazineServiceTest extends AbstractMailMagazineTestCase
         );
 
         $historyId = $this->mailMagazineService->createMailMagazineHistory(array(
+            'pref' => null,
+            'sex' => new ArrayCollection(),
+            'customer_status' => new ArrayCollection(),
             'subject' => 'subject',
             'body' => 'body',
             'multi' => 'create_mail_magazine_history@example.com',
@@ -359,6 +377,9 @@ class MailMagazineServiceTest extends AbstractMailMagazineTestCase
         );
 
         $historyId = $this->mailMagazineService->createMailMagazineHistory(array(
+            'pref' => null,
+            'sex' => new ArrayCollection(),
+            'customer_status' => new ArrayCollection(),
             'subject' => 'subject',
             'body' => 'body',
             'multi' => 'create_mail_magazine_history@example.com',
@@ -469,6 +490,9 @@ class MailMagazineServiceTest extends AbstractMailMagazineTestCase
         $this->createMailmagaCustomer('e_create_mail_magazine_history@example.com', 'name01_e', 'name02_e');
 
         $historyId = $this->mailMagazineService->createMailMagazineHistory(array(
+            'pref' => null,
+            'sex' => new ArrayCollection(),
+            'customer_status' => new ArrayCollection(),
             'subject' => 'subject',
             'body' => 'body',
             'multi' => 'create_mail_magazine_history@example.com',
@@ -533,6 +557,9 @@ class MailMagazineServiceTest extends AbstractMailMagazineTestCase
         $this->createMailmagaCustomer('e_create_mail_magazine_history@example.com', 'name01_e', 'name02_e');
 
         $historyId = $this->mailMagazineService->createMailMagazineHistory(array(
+            'pref' => null,
+            'sex' => new ArrayCollection(),
+            'customer_status' => new ArrayCollection(),
             'subject' => 'subject',
             'body' => 'body',
             'multi' => 'create_mail_magazine_history@example.com',

--- a/Tests/Web/Admin/MailMagazineControllerTest.php
+++ b/Tests/Web/Admin/MailMagazineControllerTest.php
@@ -163,7 +163,7 @@ class MailMagazineControllerTest extends MailMagazineCommon
 
 //        $Messages = $this->getMailCatcherMessages();
 //        $Message = $this->getMailCatcherMessage($Messages[0]->id);
-//
+
 //        $this->expected = $searchForm['subject'];
 //        $this->actual = $Message->subject;
 //        $this->verify();

--- a/Tests/Web/Admin/MailMagazineHistoryControllerTest.php
+++ b/Tests/Web/Admin/MailMagazineHistoryControllerTest.php
@@ -26,7 +26,7 @@ class MailMagazineHistoryControllerTest extends MailMagazineCommon
     public function testPreview()
     {
         $MailCustomer = $this->createMailMagazineCustomer();
-        $SendHistory = $this->createSendHistoy($MailCustomer);
+        $SendHistory = $this->createSendHistory($MailCustomer);
 
         $this->client->request('GET',
             $this->app->url('plugin_mail_magazine_history_preview', array('id' => $SendHistory->getId()))
@@ -55,7 +55,7 @@ class MailMagazineHistoryControllerTest extends MailMagazineCommon
     public function testCondition()
     {
         $MailCustomer = $this->createMailMagazineCustomer();
-        $SendHistory = $this->createSendHistoy($MailCustomer);
+        $SendHistory = $this->createSendHistory($MailCustomer);
 
         $this->client->request('GET',
             $this->app->url('plugin_mail_magazine_history_condition', array('id' => $SendHistory->getId()))
@@ -84,7 +84,7 @@ class MailMagazineHistoryControllerTest extends MailMagazineCommon
     public function testDelete()
     {
         $MailCustomer = $this->createMailMagazineCustomer();
-        $SendHistory = $this->createSendHistoy($MailCustomer);
+        $SendHistory = $this->createSendHistory($MailCustomer);
 
         $this->client->request('POST',
             $this->app->url('plugin_mail_magazine_history_delete', array('id' => $SendHistory->getId()))

--- a/Tests/Web/MailMagazineCommon.php
+++ b/Tests/Web/MailMagazineCommon.php
@@ -12,6 +12,8 @@
 namespace Plugin\MailMagazine\Tests\Web;
 
 use Eccube\Common\Constant;
+use Eccube\Entity\Master\CustomerStatus;
+use Eccube\Entity\Master\Sex;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use Plugin\MailMagazine\Entity\MailmagaCustomer;
 use Plugin\MailMagazine\Entity\MailMagazineSendHistory;
@@ -133,15 +135,21 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
         $SendHistory->setStartDate($currentDatetime);
 
         // json形式で検索条件を保存
-        $formData['sex'] = array();
-        foreach ($formData['sex'] as $value) {
-            $formData['sex'] = $value->toArray();
-        }
+        $formData['sex'] = array_filter(array_map(function ($entity) {
+            if ($entity instanceof Sex) {
+                return $entity->toArray();
+            } else {
+                return false;
+            }
+        }, $formData['sex']));
 
-        $formData['customer_status'] = array();
-        foreach ($formData['customer_status'] as $value) {
-            $formData['customer_status'] = $value->toArray();
-        }
+        $formData['customer_status'] = array_filter(array_map(function ($entity) {
+            if ($entity instanceof CustomerStatus) {
+                return $entity->toArray();
+            } else {
+                return false;
+            }
+        }, $formData['customer_status']));
 
         $SendHistory->setSearchData(json_encode($formData));
 

--- a/Tests/Web/MailMagazineCommon.php
+++ b/Tests/Web/MailMagazineCommon.php
@@ -79,8 +79,8 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
         return array(
             '_token' => 'dummy',
             'multi' => $MailCustomer->getId(),
-            'pref' => $MailCustomer->getPref()->getId(),
-            'sex' => array($MailCustomer->getSex()->getId()),
+            'pref' => $MailCustomer->getPref(),
+            'sex' => array($MailCustomer->getSex()),
             'birth_start' => $old_date->format('Y-m-d'),
             'birth_end' => $MailCustomer->getBirth()->format('Y-m-d'),
             'tel' => array('tel01' => $MailCustomer->getTel01(),
@@ -96,7 +96,7 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
             'update_date_end' => $MailCustomer->getUpdateDate()->format('Y-m-d'),
             'last_buy_start' => $old_date->format('Y-m-d'),
             'last_buy_end' => $MailCustomer->getLastBuyDate()->format('Y-m-d'),
-            'customer_status' => array($MailCustomer->getStatus()->getId()),
+            'customer_status' => array($MailCustomer->getStatus()),
             'buy_product_code' => $order_detail[0]->getProductName(),
             'birth_month' => $birth_month,
         );
@@ -107,8 +107,8 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
         $currentDatetime = new \DateTime();
         $MailTemplate = $this->createMagazineTemplate();
         $formData = $this->createSearchForm($MailCustomer);
-        $formData['customer_status'] = $MailCustomer->getStatus();
-        $formData['sex'] = $MailCustomer->getSex();
+        $formData['customer_status'] = array($MailCustomer->getStatus());
+        $formData['sex'] = array($MailCustomer->getSex());
         $formData = array_merge($formData, $formData['tel']);
         unset($formData['tel']);
 
@@ -131,8 +131,18 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
         $SendHistory->setCreateDate($currentDatetime);
         $SendHistory->setStartDate($currentDatetime);
 
-        // serialize
-        $SendHistory->setSearchData(base64_encode(serialize($formData)));
+        // json形式で検索条件を保存
+        $formData['sex'] = array();
+        foreach ($formData['sex'] as $value) {
+            $formData['sex'] = $value->toArray();
+        }
+
+        $formData['customer_status'] = array();
+        foreach ($formData['customer_status'] as $value) {
+            $formData['customer_status'] = $value->toArray();
+        }
+
+        $SendHistory->setSearchData(json_encode($formData));
 
         $this->app['eccube.plugin.mail_magazine.repository.mail_magazine_history']->createSendHistory($SendHistory);
 

--- a/Tests/Web/MailMagazineCommon.php
+++ b/Tests/Web/MailMagazineCommon.php
@@ -102,7 +102,7 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
         );
     }
 
-    protected function createSendHistoy(\Eccube\Entity\Customer $MailCustomer)
+    protected function createSendHistory(\Eccube\Entity\Customer $MailCustomer)
     {
         $currentDatetime = new \DateTime();
         $MailTemplate = $this->createMagazineTemplate();

--- a/Tests/Web/MailMagazineCommon.php
+++ b/Tests/Web/MailMagazineCommon.php
@@ -79,8 +79,8 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
         return array(
             '_token' => 'dummy',
             'multi' => $MailCustomer->getId(),
-            'pref' => $MailCustomer->getPref(),
-            'sex' => array($MailCustomer->getSex()),
+            'pref' => $MailCustomer->getPref()->getId(),
+            'sex' => array($MailCustomer->getSex()->getId()),
             'birth_start' => $old_date->format('Y-m-d'),
             'birth_end' => $MailCustomer->getBirth()->format('Y-m-d'),
             'tel' => array('tel01' => $MailCustomer->getTel01(),
@@ -96,7 +96,7 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
             'update_date_end' => $MailCustomer->getUpdateDate()->format('Y-m-d'),
             'last_buy_start' => $old_date->format('Y-m-d'),
             'last_buy_end' => $MailCustomer->getLastBuyDate()->format('Y-m-d'),
-            'customer_status' => array($MailCustomer->getStatus()),
+            'customer_status' => array($MailCustomer->getStatus()->getId()),
             'buy_product_code' => $order_detail[0]->getProductName(),
             'birth_month' => $birth_month,
         );
@@ -108,6 +108,7 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
         $MailTemplate = $this->createMagazineTemplate();
         $formData = $this->createSearchForm($MailCustomer);
         $formData['customer_status'] = array($MailCustomer->getStatus());
+        $formData['pref'] = $this->app['eccube.repository.master.pref']->find($formData['pref']);
         $formData['sex'] = array($MailCustomer->getSex());
         $formData = array_merge($formData, $formData['tel']);
         unset($formData['tel']);

--- a/Util/Version.php
+++ b/Util/Version.php
@@ -51,7 +51,6 @@ class Version
         return version_compare(Constant::VERSION, $version, $operation);
     }
 
-
     /**
      * Check version to support new session function.
      *

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 name: MailMagazine
 event: MailMagazine
 code: MailMagazine
-version: 1.0.1
+version: 1.0.2
 service:
     - MailMagazineServiceProvider
 orm.path:


### PR DESCRIPTION
## 概要
EC-CUBE 3.0.18で動作するようにserialize/unserializeを利用しない実装に変更しました。

メルマガの配信条件をserializeしてDBに保存していましたが、json形式で保存/取り出しするようにしています。

## 互換性について
旧バージョンのメルマガプラグインからアップデートした場合は、マイグレーション処理でDBに保存しているsearch_dataをjsonに変換する処理を追加しています。