### PR TITLE
誕生月の「1月」の検索が機能しないのを修正

### DIFF
--- a/Repository/MailMagazineCustomerRepository.php
+++ b/Repository/MailMagazineCustomerRepository.php
@@ -105,7 +105,7 @@ class MailMagazineCustomerRepository extends EntityRepository
                 ->setParameter('sexs', $sexs);
         }
         // birth_month
-        if (!empty($searchData['birth_month']) && is_int($searchData['birth_month'])) {
+        if (isset($searchData['birth_month']) && is_int($searchData['birth_month'])) {
             //Birth month start from 0 so we need plus 1.
             ++$searchData['birth_month'];
             $birthMonth = $searchData['birth_month'];


### PR DESCRIPTION
#49 への修正。

「1月」の場合、0がPOSTされるがemptyで判定しているため検索条件を通らなかったのを修正。
(開発コミュニティにて提示されていた修正コードの通りに修正)