### PR TITLE
ラベルの変数名を修正

### DIFF
--- a/Resource/template/admin/history_list.twig
+++ b/Resource/template/admin/history_list.twig
@@ -162,10 +162,10 @@ $(function () {
                                                                 </div>
                                                                 <div class="modal-footer">
                                                                     <button type="button" class="btn btn-ec-regular" data-dismiss="modal">
-                                                                        {{ 'common.label.cancel'|trans }}
+                                                                        {{ 'common.cancel'|trans }}
                                                                     </button>
                                                                     <button type="submit" class="btn btn-ec-delete" onclick="document.form1.action = '{{ url('plugin_mail_magazine_history_delete', { id: SendHistory.id }) }}'">
-                                                                        {{ 'common.label.execute'|trans }}
+                                                                        {{ 'common.delete'|trans }}
                                                                     </button>
                                                                 </div>
                                                             </div>

--- a/Resource/template/admin/template_list.twig
+++ b/Resource/template/admin/template_list.twig
@@ -66,11 +66,11 @@
                                                     </div>
                                                     <div class="modal-footer">
                                                         <button type="button" class="btn btn-ec-regular" data-dismiss="modal">
-                                                            {{ 'common.label.cancel'|trans }}
+                                                            {{ 'common.cancel'|trans }}
                                                         </button>
                                                         <form action="{{ url('plugin_mail_magazine_template_delete', { id: Template.id }) }}" method="post" enctype="application/x-www-form-urlencoded">
                                                             <button type="submit" class="btn btn-ec-delete">
-                                                                {{ 'common.label.execute'|trans }}
+                                                                {{ 'common.delete'|trans }}
                                                             </button>
                                                         </form>
                                                     </div>


### PR DESCRIPTION
#79 の修正

## 修正内容
モーダルのキャンセルと削除の変数名が間違っていたことが原因でした。

common.label.cancel →　common.cancel
common.label.execute →　common.delete

に修正したところ正しく表示されるようになりました。

また、メールマガジンテンプレートのモーダルも同じように表示が正しく表示されていなかったため合わせて修正。


