### PR TITLE
件数ドロップダウンを変更しても50件のままの不具合修正

### DIFF
--- a/Controller/MailMagazineController.php
+++ b/Controller/MailMagazineController.php
@@ -165,7 +165,7 @@ class MailMagazineController extends AbstractController
             'searchForm' => $searchForm->createView(),
             'pagination' => $pagination,
             'pageMaxis' => $pageMaxis,
-            'page_count' => $pageMax,
+            'page_count' => $pageCount,
             'has_errors' => false,
         ];
     }


### PR DESCRIPTION
#88 の修正

#74  のプルリクで件数変更ドロップダウンにより会員ページへ遷移してしまう不具合は修正されているが、件数ドロップダウンを変更しても50件表示のままのため追加で修正
