### PR TITLE
配信履歴の誕生月が1ヶ月ずれる問題の修正

### DIFF
--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -191,13 +191,6 @@ class MailMagazineHistoryController extends AbstractController
         }
         $data['sex'] = implode(', ', $val);
 
-        // 誕生月
-        $val = null;
-        if (!is_null($searchData['birth_month'])) {
-            $val = $searchData['birth_month'] + 1;
-        }
-        $data['birth_month'] = $val;
-
         return $data;
     }
 


### PR DESCRIPTION
#83 の修正
以前は誕生月が0から11の範囲になっていたため表示時に１を加算していたが
MailmagazineTypeがSearchCustomerTypeを継承したことで既に1から12の範囲となっているため不要となった