### PR TITLE
リリースタグでパッケージできるようにGitHub Actionsを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Packaging for EC-CUBE Plugin
+on:
+  release:
+    types: [ published ]
+jobs:
+  deploy:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Packaging
+        working-directory: ../
+        run: |
+          rm -rf $GITHUB_WORKSPACE/.github
+          find $GITHUB_WORKSPACE -name "dummy" -delete
+          find $GITHUB_WORKSPACE -name ".git*" -and ! -name ".gitkeep" -print0 | xargs -0 rm -rf
+          chmod -R o+w $GITHUB_WORKSPACE
+          cd $GITHUB_WORKSPACE
+          tar cvzf ../${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz ./*
+      - name: Upload binaries to release of TGZ
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ runner.workspace }}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz
+          asset_name: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
+


### PR DESCRIPTION
個人リポジトリでパッケージのテスト済み
https://github.com/okazy/mail-magazine-plugin/releases/tag/1.0.3-rc

作成されたパッケージをローカル環境にインストールできることを確認済み