### PR TITLE
配信履歴 不要なspan開始タグの削除

### DIFF
--- a/Resource/template/admin/history_result.twig
+++ b/Resource/template/admin/history_result.twig
@@ -25,7 +25,7 @@
                                 <div class="col-8">
                                     <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
                                         <span class="card-title">
-                                            {{ 'mailmagazine.history.result.number_record'|trans }} <span class="normal"><strong>{{ pagination.totalItemCount }}</strong>
+                                            {{ 'mailmagazine.history.result.number_record'|trans }} <strong>{{ pagination.totalItemCount }}</strong>
                                         </span>
                                     </div>
                                 </div>


### PR DESCRIPTION
閉じていないspanタグがあるため、特に目的がある訳ではないと思われるspan開始タグを削除。
(spanの閉じタグは省略不可のはずなので)