### PR TITLE
CIのphpバージョンのマトリクスを修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,11 @@ jobs:
             dbpass: 'password'
             dbname: 'myapp_test'
             dbversion: 9.5
+        exclude:
+          - eccube_version: 4.1
+            php: '7.1'
+          - eccube_version: 4.1
+            php: '7.2'
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
CI にて、EC-CUBE 4.1 と PHP 7.1 / 7.2 の組み合わせでテストが回っており、落ちていた
EC-CUBE 4.1 のシステム要件は PHP 7.3以上のため、4.1 × PHP 7.1 / 7.2 の組み合わせをスキップするように修正しました

issue: #118 
