### PR TITLE
配信履歴-配信結果画面でページャー設置と件数変更の不具合修正

### DIFF
--- a/Controller/MailMagazineHistoryController.php
+++ b/Controller/MailMagazineHistoryController.php
@@ -289,11 +289,9 @@ class MailMagazineHistoryController extends AbstractController
         $pageCount = $request->get('page_count');
         $pageCount = $pageCount ? $pageCount : $this->eccubeConfig['eccube_default_page_count'];
 
-        $pageNo = $page_no;
         $pagination = $paginator->paginate($resultFile,
-            empty($pageNo) ? 1 : $pageNo,
-            $pageCount,
-            ['total' => 1]
+            $page_no,
+            $pageCount
         );
 
         return [

--- a/Event/MailMagazineHistoryFilePaginationSubscriber.php
+++ b/Event/MailMagazineHistoryFilePaginationSubscriber.php
@@ -50,29 +50,29 @@ class MailMagazineHistoryFilePaginationSubscriber implements EventSubscriberInte
             return;
         }
 
-        $event->count = $event->options['total'];
-
         $skip = $event->getOffset();
         $fp = fopen($file, 'r');
         $count = $event->getLimit();
+        $total = 0;
 
         $event->items = [];
         while ($line = fgets($fp)) {
+            $total++;
             if ($skip-- > 0) {
                 continue;
             }
-            if ($count == 0) {
-                break;
+            if ($count > 0) {
+                list($status, $customerId, $email, $name) = explode(',', str_replace(PHP_EOL, '', $line), 4);
+                $event->items[] = [
+                    'status' => $status,
+                    'customerId' => $customerId,
+                    'email' => $email,
+                    'name' => $name,
+                ];
             }
-            list($status, $customerId, $email, $name) = explode(',', str_replace(PHP_EOL, '', $line), 4);
-            $event->items[] = [
-                'status' => $status,
-                'customerId' => $customerId,
-                'email' => $email,
-                'name' => $name,
-            ];
             --$count;
         }
+        $event->count = $total;
     }
 
     public static function getSubscribedEvents()

--- a/Resource/template/admin/history_result.twig
+++ b/Resource/template/admin/history_result.twig
@@ -42,7 +42,7 @@
                                     <select class="custom-select" onchange="location = this.value;">
                                         {% for pageMax in pageMaxis %}
                                             <option {% if pageMax.name == page_count %} selected {% endif %}
-                                                    value="{{ path('admin_customer_page', {'page_no': 1, 'page_count': pageMax.name }) }}">
+                                                    value="{{ path('plugin_mail_magazine_history_result_page', {'id': historyId, 'page_no': 1, 'page_count': pageMax.name }) }}">
                                                 {{ 'admin.common.count'|trans({ '%count%': pageMax.name }) }}</option>
                                         {% endfor %}
                                     </select>
@@ -89,6 +89,11 @@
                                 {% endfor %}
                                 </tbody>
                             </table>
+                            <div class="row justify-content-md-center mb-4">
+                                {% if pagination.totalItemCount > 0 %}
+                                    {% include "@MailMagazine4/admin/history_result_pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'plugin_mail_magazine_history_result_page' } %}
+                                {% endif %}
+                            </div>
                         </div>
                     {% else %}
                         <div class="card-body mb-lg-5">

--- a/Resource/template/admin/history_result_pager.twig
+++ b/Resource/template/admin/history_result_pager.twig
@@ -1,0 +1,71 @@
+{#
+ This file is part of EC-CUBE
+
+ Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ http://www.ec-cube.co.jp/
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+#}
+{% if pages.pageCount > 1 %}
+    <ul class="pagination">
+
+        <!-- 最初へ -->
+        {% if pages.firstPageInRange != 1 %}
+            <li class="page-item">
+                {# FIXME: Need check pass routes before use default _route from request #}
+                <a class="page-link" href="{{ path(
+                    routes ? routes : app.request.attributes.get('_route'),
+                    app.request.attributes.get('_route_params')|merge(app.request.query.all|merge({'page_no': pages.first}))) }}">{{ 'admin.common.first'|trans }}</a></li>
+
+        {% endif %}
+
+        <!-- 前へ -->
+        {% if pages.previous is defined %}
+            <li class="page-item">
+                {# FIXME: Need check pass routes before use default _route from request #}
+                <a class="page-link"
+                   href="{{ path(routes ? routes : app.request.attributes.get('_route'), app.request.attributes.get('_route_params')|merge(app.request.query.all|merge({'page_no': pages.previous}))) }}">{{ 'admin.common.prev'|trans }}</a>
+            </li>
+        {% endif %}
+
+        <!-- 1ページリンクが表示されない場合、「...」を表示 -->
+        {% if pages.firstPageInRange != 1 %}
+            <li class="page-item">...</li>
+        {% endif %}
+
+        {% for page in pages.pagesInRange %}
+            <li class="page-item{% if page == pages.current %} active{% endif %}">
+                {# FIXME: Need check pass routes before use default _route from request #}
+                <a class="page-link"
+                   href="{{ path(routes ? routes : app.request.attributes.get('_route'),app.request.attributes.get('_route_params')|merge(app.request.query.all|merge({'page_no': page}))) }}">
+                    {{ page }}
+                </a>
+            </li>
+        {% endfor %}
+
+        <!-- 最終ページリンクが表示されない場合、「...」を表示 -->
+        {% if pages.last != pages.lastPageInRange %}
+            <li class="page-item">...</li>
+        {% endif %}
+
+        <!-- 次へ -->
+        {% if pages.next is defined %}
+            <li class="page-item">
+                {# FIXME: Need check pass routes before use default _route from request #}
+                <a class="page-link"
+                   href="{{ path(routes ? routes : app.request.attributes.get('_route'),app.request.attributes.get('_route_params')|merge(app.request.query.all|merge({'page_no': pages.next}))) }}">{{ 'admin.common.next'|trans }}</a>
+            </li>
+        {% endif %}
+
+        <!-- 最後へ -->
+        {% if pages.last != pages.lastPageInRange %}
+            <li class="page-item">
+                {# FIXME: Need check pass routes before use default _route from request #}
+                <a class="page-link" href="{{ path(
+                    routes ? routes : app.request.attributes.get('_route'),
+                    app.request.attributes.get('_route_params')|merge(app.request.query.all|merge({'page_no': pages.last}))) }}">{{ 'admin.common.last'|trans }}</a></li>
+        {% endif %}
+
+    </ul>
+{% endif %}


### PR DESCRIPTION
### PRで修正したい内容
1. 件数変更のプルダウンを選択すると会員一覧ページへ遷移する
2. 配信件数が50件を超えてもページャーが表示されない
3. 配信件数が何件であっても常に「総件数 1」と表示されている

<img width="1106" alt="mailmagazine4_history_result" src="https://user-images.githubusercontent.com/4304985/161701247-15119b5f-256b-4b80-b0fe-aa5a29d6d036.png">
