### PR TITLE
Deprecated な html タグが使われているので現行のものに置換する

### DIFF
--- a/Resource/template/admin/confirm.twig
+++ b/Resource/template/admin/confirm.twig
@@ -96,11 +96,11 @@
                                     </tr>
                                     <tr>
                                         <th>{{ 'mailmagazine.select.label_body'|trans }}</th>
-                                        <td><xmp>{{ body_itm }}</xmp></td>
+                                        <td><pre>{{ body_itm }}</pre></td>
                                     </tr>
                                     <tr>
                                         <th>{{ 'mailmagazine.select.label_body_html'|trans }}</th>
-                                        <td><xmp>{{ htmlBody_itm|raw }}</xmp></td>
+                                        <td><pre>{{ htmlBody_itm|raw }}</pre></td>
                                     </tr>
                                 </tbody>
                             </table>

--- a/Resource/template/admin/history_preview.twig
+++ b/Resource/template/admin/history_preview.twig
@@ -26,11 +26,11 @@
                 </tr>
                 <tr>
                     <th>{{ 'mailmagazine.select.label_body'|trans }}</th>
-                    <td><xmp>{{ history.body }}</xmp></td>
+                    <td><pre>{{ history.body }}</pre></td>
                 </tr>
                 <tr>
                     <th>{{ 'mailmagazine.select.label_body_html'|trans }}</th>
-                    <td><xmp>{{ history.htmlBody|raw }}</xmp></td>
+                    <td><pre>{{ history.htmlBody|raw }}</pre></td>
                 </tr>
                 </tbody>
             </table>

--- a/Resource/template/admin/preview.twig
+++ b/Resource/template/admin/preview.twig
@@ -28,11 +28,11 @@
                             </tr>
                             <tr>
                                 <th class="w-25">{{ 'mailmagazine.select.label_body'|trans }}</th>
-                                <td><xmp>{{ Template.body }}</xmp></td>
+                                <td><pre>{{ Template.body }}</pre></td>
                             </tr>
                             <tr>
                                 <th class="w-25">{{ 'mailmagazine.select.label_body_html'|trans }}</th>
-                                <td><xmp>{{ Template.htmlBody|raw }}</xmp></td>
+                                <td><pre>{{ Template.htmlBody|raw }}</pre></td>
                             </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
# 概要

template 内で非推奨(Deprecated)の&lt;xmp&gt;タグが使われているので、現行の&lt;pre&gt;タグに置き換える

参考
https://developer.mozilla.org/ja/docs/Web/HTML/Element/xmp

# テスト

変更していません

# マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

# レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか