### PR TITLE
ボタンのレイアウトを配信画面で統一

### DIFF
--- a/Resource/template/admin/index.twig
+++ b/Resource/template/admin/index.twig
@@ -368,13 +368,13 @@ function fnChangeActionSubmit(action) {
                                     {% include "@admin/pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'plugin_mail_magazine_page' } %}
                                 {% endif %}
                             </div>
-                            <div class="row justify-content-md-center mb-4 ">
-                                <div class="col-auto">
-                                    <button class="btn btn-ec-regular btn-lg" onclick="fnChangeActionSubmit('{{ url('plugin_mail_magazine_select') }}'); return false;">
-                                        {{ 'mailmagazine.index.btn_select_template'|trans }}
-                                    </button>
-                                </div>
-                            </div>
+                        </div>
+                    </div>
+                    <div class="row justify-content-md-center mb-4 ">
+                        <div class="col-auto">
+                            <button class="btn btn-ec-regular ps-4 pe-4" onclick="fnChangeActionSubmit('{{ url('plugin_mail_magazine_select') }}'); return false;">
+                                {{ 'mailmagazine.index.btn_select_template'|trans }}
+                            </button>
                         </div>
                     </div>
                 {% elseif has_errors %}

--- a/Resource/template/admin/template_list.twig
+++ b/Resource/template/admin/template_list.twig
@@ -90,7 +90,7 @@
                 </div>
                 <div class="row justify-content-md-center mb-4 ">
                     <div class="col-auto">
-                        <a class="btn btn-ec-regular btn-lg" href="{{ url('plugin_mail_magazine_template_regist') }}">
+                        <a class="btn btn-ec-regular ps-4 pe-4" href="{{ url('plugin_mail_magazine_template_regist') }}">
                             {{ 'mailmagazine.template.btn_new'|trans }}
                         </a>
                     </div>


### PR DESCRIPTION
[#135](https://github.com/EC-CUBE/mail-magazine-plugin/issues/135)のissueに対応しました

配信画面のほうをテンプレート設定画面の方に寄せました
またどちらの画面もボタンのサイズを小さくしました

配信画面
![image](https://user-images.githubusercontent.com/8424850/187233573-2075665b-0ad1-471e-9616-558e3d1506b1.png)
