### PR TITLE
ラジオボタンのエラーメッセージにスタイルが当たるように修正

### DIFF
--- a/Resource/template/entry_add_mailmaga.twig
+++ b/Resource/template/entry_add_mailmaga.twig
@@ -27,20 +27,18 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             {{- form_label(form) -}}
         </dt>
         <dd>
-            <div class="form-group form-inline">
-                <div class="ec-radio">
-                    {% if (app.request.get('mode') == 'confirm' and form.parent.vars.valid) %}
-                        {% for choice in form.vars.choices %}
-                            {% if choice.data == form.vars.data %}
-                                {{- choice.label|trans -}}
-                            {% endif %}
-                        {% endfor %}
-                        {{- form_widget(form, {type : 'hidden'}) -}}
-                    {% else %}
-                        {{- form_widget(form) -}}
-                        {{- form_errors(form) -}}
-                    {% endif %}
-                </div>
+            <div class="ec-radio{{ has_errors(form) ? ' error' }}">
+                {% if (app.request.get('mode') == 'confirm' and form.parent.vars.valid) %}
+                    {% for choice in form.vars.choices %}
+                        {% if choice.data == form.vars.data %}
+                            {{- choice.label|trans -}}
+                        {% endif %}
+                    {% endfor %}
+                    {{- form_widget(form, {type : 'hidden'}) -}}
+                {% else %}
+                    {{- form_widget(form) -}}
+                    {{- form_errors(form) -}}
+                {% endif %}
             </div>
         </dd>
     </dl>


### PR DESCRIPTION
[♯111](https://github.com/EC-CUBE/mail-magazine-plugin/issues/111)のissueに対応しました

![image](https://user-images.githubusercontent.com/8424850/187241930-5e001899-f22b-47d6-b8e6-890399619f61.png)


ref [♯5541](https://github.com/EC-CUBE/ec-cube/pull/5541)