### PR TITLE
参照していないjavascriptのコードを削除

### DIFF
--- a/Resource/template/admin/index.twig
+++ b/Resource/template/admin/index.twig
@@ -77,27 +77,6 @@ $(function() {
             showTodayButton: true
         });
     }
-
-    (function($, f) {
-        //フォームがないページは処理キャンセル
-        var $ac = $(".accpanel");
-        if (!$ac) {
-            console.log('cancel');
-            return false
-        }
-
-        //フォーム内全項目取得
-        var c = f();
-        if (c.formState()) {
-            if ($ac.css("display") == "none") {
-                $ac.siblings('.toggle').addClass("active");
-                $ac.slideDown(0);
-            }
-        } else {
-            $ac.siblings('.toggle').removeClass("active");
-            $ac.slideUp(0);
-        }
-    })($, formPropStateSubscriber);
 });
 
 function fnChangeActionSubmit(action) {


### PR DESCRIPTION
[#141](https://github.com/EC-CUBE/mail-magazine-plugin/issues/141)のissueに対応しました。

formPropStateSubscriberというメソッドが3系には存在することを確認しました。
今回の該当の画面には関係ない処理内容でしたので削除しました。