### PR TITLE
配信先のCSVダウンロード機能を追加

### DIFF
--- a/Resource/template/admin/index.twig
+++ b/Resource/template/admin/index.twig
@@ -308,7 +308,10 @@ function fnChangeActionSubmit(action) {
                                 </select>
                             </div>
                             <div class="d-inline-block">
-                                <div class="btn-group" role="group"></div>
+                                <div class="btn-group" role="group">
+                                    <a class="btn btn-ec-regular" href="{{ url('plugin_mail_magazine_export') }}"><i class="fa fa-cloud-download me-1 text-secondary"></i><span>{{ 'admin.common.csv_download'|trans }}</span></a>
+                                    <a class="btn btn-ec-regular" href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_CUSTOMER') }) }}"><i class="fa fa-cog me-1 text-secondary"></i><span>{{ 'admin.setting.shop.csv_setting'|trans }}</span></a>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/Tests/Web/Admin/MailMagazineControllerTest.php
+++ b/Tests/Web/Admin/MailMagazineControllerTest.php
@@ -222,4 +222,22 @@ class MailMagazineControllerTest extends MailMagazineCommon
         $sexCheckbox = $crawler->filter('#mail_magazine_sex_1:checked')->count();
         $this->assertEquals(1, $sexCheckbox);
     }
+
+    /**
+     * testExport
+     */
+    public function testExport()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->createMailMagazineCustomer('user-'.$i.'@example.com');
+        }
+
+        $this->expectOutputRegex('/user-[0-9]@example.com/');
+
+        $this->client->request(
+            'GET',
+            $this->generateUrl('plugin_mail_magazine_export'),
+            ['mail_magazine' => ['_token' => 'dummy']]
+        );
+    }
 }

--- a/Tests/Web/MailMagazineCommon.php
+++ b/Tests/Web/MailMagazineCommon.php
@@ -57,14 +57,14 @@ class MailMagazineCommon extends AbstractAdminWebTestCase
         return $MailTemplate;
     }
 
-    protected function createMailMagazineCustomer()
+    protected function createMailMagazineCustomer($email = null)
     {
         $fake = $this->getFaker();
         $current_date = new \DateTime();
 
         $Sex = $this->sexRepository->find(1);
 
-        $Customer = $this->createCustomer();
+        $Customer = $this->createCustomer($email);
         $Customer
             ->setSex($Sex)
             ->setBirth($current_date->modify('-20 years'))


### PR DESCRIPTION
現状では会員管理にてメルマガの希望状態によって絞り込むことができず、メルマガ希望者のCSVをダウンロードできなくて不便なので、配信画面にCSVダウンロードの機能を追加しました

#54 メルマガ配信対象者のCSVダウンロード機能の追加