### PR TITLE
Fix:再送信用の一時ファイルの保存場所を4.0仕様に合わせて修正 (refs #62)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
         id: composer-cache
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        eccube_version: [ '4.2', '4.3-symfony6' ]
+        eccube_version: [ '4.2', '4.3' ]
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
         db: [ 'mysql', 'mysql8', 'pgsql' ]
         plugin_code: [ 'MailMagazine42' ]
@@ -43,9 +43,9 @@ jobs:
               php: 8.2
           -   eccube_version: 4.2
               php: 8.3
-          -   eccube_version: 4.3-symfony6
+          -   eccube_version: 4.3
               php: 7.4
-          -   eccube_version: 4.3-symfony6
+          -   eccube_version: 4.3
               php: 8.0
     services:
       mysql:

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -1,5 +1,5 @@
 parameters:
-    mail_magazine_dir: '%kernel.project_dir%/app/mail_magazine'
+    mail_magazine_dir: '%kernel.project_dir%/app/PluginData/mail_magazine'
 
 services:
     Plugin\MailMagazine42\Entity\AdminCustomerQueryCustomizer:

--- a/Tests/Util/MailMagazineHistoryFilePaginationSubscriberTest.php
+++ b/Tests/Util/MailMagazineHistoryFilePaginationSubscriberTest.php
@@ -19,6 +19,7 @@ use Plugin\MailMagazine42\Tests\AbstractMailMagazineTestCase;
 use Plugin\MailMagazine42\Service\MailMagazineService;
 use Plugin\MailMagazine42\Event\MailMagazineHistoryFilePaginationSubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Event\Subscriber\Sortable\SortableSubscriber;
 
@@ -156,7 +157,7 @@ class MailMagazineHistoryFilePaginationSubscriberTest extends AbstractMailMagazi
         $eventDispatcher->addSubscriber(new SortableSubscriber);
         $eventDispatcher->addSubscriber(self::getContainer()->get(MailMagazineHistoryFilePaginationSubscriber::class));
 
-        $paginator = new Paginator($eventDispatcher);
+        $paginator = new Paginator($eventDispatcher, new RequestStack());
 
         return $paginator->paginate($file, $page, $limit, ['total' => $total]);
     }

--- a/Tests/Util/MailMagazineHistoryFilePaginationSubscriberTest.php
+++ b/Tests/Util/MailMagazineHistoryFilePaginationSubscriberTest.php
@@ -22,7 +22,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Event\Subscriber\Sortable\SortableSubscriber;
-use Knp\Component\Pager\ArgumentAccess\RequestArgumentAccess;
 
 class MailMagazineHistoryFilePaginationSubscriberTest extends AbstractMailMagazineTestCase
 {
@@ -158,9 +157,17 @@ class MailMagazineHistoryFilePaginationSubscriberTest extends AbstractMailMagazi
         $eventDispatcher->addSubscriber(new SortableSubscriber);
         $eventDispatcher->addSubscriber(self::getContainer()->get(MailMagazineHistoryFilePaginationSubscriber::class));
 
-        $requestStack = new RequestStack();
-        $accessor = new RequestArgumentAccess($requestStack);
-        $paginator = new Paginator($eventDispatcher, $accessor);
+        if (class_exists(\Knp\Component\Pager\ArgumentAccess\RequestArgumentAccess::class)) {
+            // ECCUBE 4.3 (knplabs/knp-components v5.2) 対応
+            $requestStack = new RequestStack();
+            $accessor = new \Knp\Component\Pager\ArgumentAccess\RequestArgumentAccess($requestStack);
+            $paginator = new Paginator($eventDispatcher, $accessor);
+        } else {
+            // ECCUBE 4.2 (knplabs/knp-components v3.6) 対応
+            $paginator = new Paginator($eventDispatcher);
+        }
+
+
         return $paginator->paginate($file, $page, $limit, ['total' => $total]);
     }
 

--- a/Tests/Util/MailMagazineHistoryFilePaginationSubscriberTest.php
+++ b/Tests/Util/MailMagazineHistoryFilePaginationSubscriberTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Event\Subscriber\Sortable\SortableSubscriber;
-use Knp\Component\Pager\ArgumentAccess\ArgumentAccess;
+use Knp\Component\Pager\ArgumentAccess\RequestArgumentAccess;
 
 class MailMagazineHistoryFilePaginationSubscriberTest extends AbstractMailMagazineTestCase
 {
@@ -158,7 +158,9 @@ class MailMagazineHistoryFilePaginationSubscriberTest extends AbstractMailMagazi
         $eventDispatcher->addSubscriber(new SortableSubscriber);
         $eventDispatcher->addSubscriber(self::getContainer()->get(MailMagazineHistoryFilePaginationSubscriber::class));
 
-        $paginator = new Paginator($eventDispatcher, new ArgumentAccess(), new RequestStack());
+        $requestStack = new RequestStack();
+        $accessor = new RequestArgumentAccess($requestStack);
+        $paginator = new Paginator($eventDispatcher, $accessor);
         return $paginator->paginate($file, $page, $limit, ['total' => $total]);
     }
 

--- a/Tests/Util/MailMagazineHistoryFilePaginationSubscriberTest.php
+++ b/Tests/Util/MailMagazineHistoryFilePaginationSubscriberTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Event\Subscriber\Sortable\SortableSubscriber;
+use Knp\Component\Pager\ArgumentAccess\ArgumentAccess;
 
 class MailMagazineHistoryFilePaginationSubscriberTest extends AbstractMailMagazineTestCase
 {
@@ -157,8 +158,7 @@ class MailMagazineHistoryFilePaginationSubscriberTest extends AbstractMailMagazi
         $eventDispatcher->addSubscriber(new SortableSubscriber);
         $eventDispatcher->addSubscriber(self::getContainer()->get(MailMagazineHistoryFilePaginationSubscriber::class));
 
-        $paginator = new Paginator($eventDispatcher, new RequestStack());
-
+        $paginator = new Paginator($eventDispatcher, new ArgumentAccess(), new RequestStack());
         return $paginator->paginate($file, $page, $limit, ['total' => $total]);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ec-cube/mailmagazine42",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "メールマガジンプラグイン",
   "type": "eccube-plugin",
   "require": {


### PR DESCRIPTION
・再送信用の一時ファイルの保存場所を4.0仕様に合わせて以下の配下に保存するように変更（Fixed #62）
　一時ファイルの保存場所：app/PluginData/mail_magazine

・テストコードおよびテスト環境構築定義を変更